### PR TITLE
Replaced busboy with formidable

### DIFF
--- a/packages/multipart/multipart_server.js
+++ b/packages/multipart/multipart_server.js
@@ -1,19 +1,38 @@
-var busboy = Npm.require('connect-busboy');
-Router.onBeforeAction(busboy({immediate: true}));
+var formidable = Npm.require('formidable');
+
 Router.onBeforeAction(function (req, res, next) {
-  if (req.busboy) {
-    req.files = [];
-    req.busboy.on('file', Meteor.bindEnvironment(function (fieldname, file, filename, encoding, mimetype) {
-      req.files.push({
-        file: file,
-        fieldname: fieldname,
-        filename: filename,
-        encoding: encoding,
-        mimetype: mimetype
-      });
+
+  var form = new formidable.IncomingForm();
+
+    form.parse(req, function(err, fields, files) {
+
+      if(fields){
+
+        if(req.body){
+
+        } else {
+          req.body = {};
+        }
+
+        _.extend(req.body, fields);
+
+      }
+
+      if(files){
+
+        if(req.files){
+
+        } else {
+          req.files = {};
+        }
+
+        _.extend(req.files, files);
+
+      }
+
       next();
-    }));
-  } else {
-    next();
-  }
+
+    });  
+
+
 });

--- a/packages/multipart/multipart_server.js
+++ b/packages/multipart/multipart_server.js
@@ -1,20 +1,29 @@
-var formidable = Npm.require('formidable');
+var multiparty = Npm.require('multiparty');
+var util = Npm.require('util');
 
 Router.onBeforeAction(function (req, res, next) {
 
-  var form = new formidable.IncomingForm();
+  var form = new multiparty.Form();
 
     form.parse(req, function(err, fields, files) {
+
+
 
       if(fields){
 
         if(req.body){
 
         } else {
+
           req.body = {};
+
         }
 
-        _.extend(req.body, fields);
+        _.each(fields, function(f, key){
+
+          req.body[key] = f[0];
+
+        });
 
       }
 
@@ -26,9 +35,29 @@ Router.onBeforeAction(function (req, res, next) {
           req.files = {};
         }
 
-        _.extend(req.files, files);
+        // parse files for backwards compatability with iron-router 0.8.3
+
+        _.each(files, function(val, idx){
+
+          req.files[idx] = {
+            originalFilename: val[0].originalFilename,
+            path: val[0].path,
+            headers: val[0].headers,
+            name: val[0].originalFilename,
+            size: val[0].size
+          };
+
+        });
 
       }
+
+      /*
+      console.log(util.inspect(fields, showHidden=false, depth=3, colorize=true));      
+      console.log(util.inspect(files, showHidden=false, depth=3, colorize=true));      
+
+      console.log(util.inspect(req.body.fields, showHidden=false, depth=3, colorize=true));      
+      console.log(util.inspect(req.files, showHidden=false, depth=3, colorize=true));      
+      */
 
       next();
 

--- a/packages/multipart/package.js
+++ b/packages/multipart/package.js
@@ -5,7 +5,8 @@ Package.describe({
 });
 
 Npm.depends({
-  'connect-busboy': '0.0.2'
+//  'connect-busboy': '0.0.2'
+  'formidable': '1.0.16'
 });
 
 Package.onUse(function (api) {

--- a/packages/multipart/package.js
+++ b/packages/multipart/package.js
@@ -6,7 +6,7 @@ Package.describe({
 
 Npm.depends({
 //  'connect-busboy': '0.0.2'
-  'formidable': '1.0.16'
+  'multiparty': '4.1.1'
 });
 
 Package.onUse(function (api) {


### PR DESCRIPTION
- busboy apparently does not return fields _and_ files together - formidable does
- this logic is still not backwards compatible with the pre Meteor 0.9 iron router
